### PR TITLE
evmkit github repo link included in the side nav and footer

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -36,6 +36,11 @@
       "name": "Discord",
       "icon": "discord",
       "url": "https://discord.com/invite/4eQBm7DDNS"
+    },
+    {
+      "name": "Github",
+      "icon": "github",
+      "url": "https://github.com/jarrodwatts/evmkit"
     }
   ],
   "navigation": [
@@ -63,6 +68,7 @@
   ],
   "footerSocials": {
     "twitter": "https://twitter.com/jarrodwattsdev",
-    "discord": "https://discord.com/invite/4eQBm7DDNS"
+    "discord": "https://discord.com/invite/4eQBm7DDNS",
+    "github": "https://github.com/jarrodwatts/evmkit"
   }
 }


### PR DESCRIPTION
evmkit github repo link was missing on the evmkit documentation website.



_Included in the side navigation:_
<img width="320" alt="Screenshot 2023-07-03 at 5 55 14 PM" src="https://github.com/jarrodwatts/evmkit-docs/assets/12666706/b40893af-41ac-4374-8269-182698b87850">



_Included in the footer:_
<img width="264" alt="Screenshot 2023-07-03 at 5 55 20 PM" src="https://github.com/jarrodwatts/evmkit-docs/assets/12666706/26e3d42e-c370-4d17-ab0b-a1134b150af3">
